### PR TITLE
fix(http): contener dentro de su base los estáticos del dev server y el listado de file-storage

### DIFF
--- a/src/providers/files/file-storage/index.ts
+++ b/src/providers/files/file-storage/index.ts
@@ -1,4 +1,5 @@
 import { IStorage } from "../../../interfaces/modules/providers/IStorage.js";
+import { isInsideBase } from "@common/utils/path-containment.ts";
 import { BaseProvider, ProviderType } from "../../BaseProvider.js";
 
 import * as fs from "node:fs/promises";
@@ -83,7 +84,13 @@ export default class FileStorageProvider extends BaseProvider implements IStorag
 	}
 
 	async list(subPath?: string): Promise<string[]> {
-		const dirPath = subPath ? path.join(this.#basePath, subPath) : this.#basePath;
+		const dirPath = subPath ? path.resolve(this.#basePath, subPath) : path.resolve(this.#basePath);
+		// `save`/`load`/`delete` se defienden con `basename`; el listado admite subdirectorios, así
+		// que acá la defensa es la contención dentro de `#basePath`.
+		if (!isInsideBase(this.#basePath, dirPath)) {
+			this.logger.logError(`Listado fuera del almacenamiento: ${subPath}`);
+			return [];
+		}
 		try {
 			const files = await fs.readdir(dirPath);
 			// Devolver solo los nombres de archivo sin la extensión .bin

--- a/src/services/core/UIFederationService/strategies/shared/vite-static.ts
+++ b/src/services/core/UIFederationService/strategies/shared/vite-static.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { getCommonPublicDir } from "../../utils/fs/path-resolver.js";
+import { isInsideBase } from "@common/utils/path-containment.ts";
 import type { IBuildContext } from "../types.js";
 
 /** Mapa consolidado de extensiones a content-types para servir archivos estáticos */
@@ -21,6 +22,23 @@ const STATIC_CONTENT_TYPES: Record<string, string> = {
 	".txt": "text/plain; charset=utf-8",
 	".webmanifest": "application/manifest+json",
 };
+
+/**
+ * Resuelve el path de una request dentro de `baseDir`, o `null` si se escapa. `req.url` es el path
+ * crudo del cliente: un `GET /ui/../../etc/passwd` (o su versión percent-encoded) llega tal cual,
+ * sin que el navegador lo normalice.
+ */
+function resolveInsideDir(baseDir: string, requestPath: string): string | null {
+	let decoded: string;
+	try {
+		decoded = decodeURIComponent(requestPath);
+	} catch {
+		return null;
+	}
+	if (decoded.includes("\0")) return null;
+	const resolved = path.resolve(baseDir, `.${decoded.startsWith("/") ? "" : "/"}${decoded}`);
+	return isInsideBase(baseDir, resolved) ? resolved : null;
+}
 
 /**
  * Sirve un archivo estático con el content-type apropiado.
@@ -66,8 +84,8 @@ export function createStaticAssetsPlugin(context: IBuildContext): any {
 
 				const relativePath = req.url.slice(4);
 				for (const dir of uiLibraryDirs) {
-					const filePath = path.join(dir, relativePath);
-					if (serveStaticFile(filePath, res, 31536000)) return;
+					const filePath = resolveInsideDir(dir, relativePath);
+					if (filePath && serveStaticFile(filePath, res, 31536000)) return;
 				}
 				next();
 			});
@@ -89,8 +107,8 @@ export function createCommonPublicFallbackPlugin(): any {
 				if (!req.url || req.url.startsWith("/ui/") || req.url.startsWith("/@")) return next();
 
 				const cleanUrl = req.url.split("?")[0].split("#")[0];
-				const filePath = path.join(commonDir, cleanUrl);
-				if (serveStaticFile(filePath, res, 86400)) return;
+				const filePath = resolveInsideDir(commonDir, cleanUrl);
+				if (filePath && serveStaticFile(filePath, res, 86400)) return;
 				next();
 			});
 		},


### PR DESCRIPTION
Parte de una revisión de path traversal en las rutas de subida y servido de archivos. El grueso de los hallazgos estaba en el túnel del Drive (va en `adc-drive`, branch homónimo); acá quedan los dos de la plataforma.

## Qué se arregla

**1. Estáticos del dev server (`strategies/shared/vite-static.ts`)**

Los dos plugins de Vite que sirven estáticos —`/ui/` de las UI libraries y el fallback de `common/public/`— hacían `path.join(dir, req.url)`. `req.url` es el path crudo del cliente, sin normalizar por el navegador, así que:

```
GET /../../../../../../etc/passwd   → 200 con el archivo
```

Sólo afecta al dev server (`configureServer`): producción resuelve por `resolveSafeStaticPath`, que ya contiene. Pero el traversal era real y lo verifiqué contra el código actual.

**2. `file-storage.list()` (`providers/files/file-storage/index.ts`)**

`save`/`load`/`delete` se defienden con `path.basename`, pero el listado admite subdirectorios y hacía `path.join(basePath, subPath)` sin comprobar contención. Hoy ningún caller le pasa input de usuario; queda cerrado igual.

## Cómo

Ambos pasan ahora por `isInsideBase` (`@common/utils/path-containment`), decodificando **antes** de resolver: si se compara el path crudo, `%2e%2e` esquiva la comprobación pero abre el mismo archivo. Un path que se sale se trata como "no encontrado" (`next()` / `[]`), no como error.

## Verificación

- Repro previo confirmado sobre el código sin el parche: `GET /../../../../../../etc/passwd` servía el archivo y `list("../../…/etc")` listaba fuera de la base. Con el parche, 404 y `[]`.
- Casos legítimos intactos: `/favicon.ico` se sigue sirviendo desde `common/public/`, y el listado dentro de la base no cambia.
- `bun run lint` (`eslint src presets --max-warnings 0`): limpio.
- `tsgo --noEmit` por proyecto: mismos errores que el baseline del clon fresco (`public-env.generated.ts` y `@ui-library/utils/react-jsx` son generados por `build:ui`; `archiver` no está instalado). Cero en los archivos tocados.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J1iJKyzQ6q3p6EXxmbeN8i)_